### PR TITLE
Fixing broken paper-fullscreen-dialog element definition

### DIFF
--- a/paper-fullscreen-dialog.html
+++ b/paper-fullscreen-dialog.html
@@ -120,6 +120,9 @@ Example "edit" dialog:
   </template>
   <script>
     Polymer({
+
+      is: 'paper-fullscreen-dialog',
+
       /**
        * Fired when the narrow layout changes.
        *


### PR DESCRIPTION
Set "is" property to "paper-fullscreen-dialog".

Without this vulcanizing fails (i.e Crisper)
